### PR TITLE
Fix for plugin-modified events

### DIFF
--- a/src/main/java/to/epac/factorycraft/bossbarhealth/handlers/DamageHandler.java
+++ b/src/main/java/to/epac/factorycraft/bossbarhealth/handlers/DamageHandler.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -18,7 +19,7 @@ import java.util.Map;
 
 public class DamageHandler implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onDamage(EntityDamageEvent event) {
         Entity victim = event.getEntity();
 

--- a/src/main/java/to/epac/factorycraft/bossbarhealth/handlers/RegainHealthHandler.java
+++ b/src/main/java/to/epac/factorycraft/bossbarhealth/handlers/RegainHealthHandler.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -15,7 +16,7 @@ import java.util.Map;
 
 public class RegainHealthHandler implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onRegainHealth(EntityRegainHealthEvent event) {
         LivingEntity entity = (LivingEntity) event.getEntity();
 


### PR DESCRIPTION
The bossbar is now displayed in the MONITOR stage of the EntityDamageEvent and EntityRegainHealthEvent, so as to allow other plugins to apply their own changes to them first.